### PR TITLE
Fixing button rendering in Foundry 13.

### DIFF
--- a/release_notes/1.1.0.md
+++ b/release_notes/1.1.0.md
@@ -2,4 +2,4 @@
 
 - The domains of HTTP(S) paths are now also checked for validity. Checking the complete path is prevented by Foundry's CORS policy.
 - The validity checks are no longer case-sensitive on windows.
-- AssetAuditor not supports wildcards in Tokens, just like Foundry does.
+- AssetAuditor now supports wildcards in Tokens, just like Foundry does.

--- a/release_notes/2.0.0.md
+++ b/release_notes/2.0.0.md
@@ -1,0 +1,4 @@
+# Version 2.0.0
+
+- Fixing Rendering of Button in Foundry 13.
+- **BREAKING:** Dropping support for Foundry versions below 13. If you are using Foundry 11 or 12, keep using AssetAuditor 1.1.0.

--- a/src/module.json
+++ b/src/module.json
@@ -8,10 +8,10 @@
       "email": "thecomamba@jojoheinze.de"
     }
   ],
-  "version": "1.1.0",
+  "version": "2.0.0",
   "compatibility": {
-    "minimum": "11",
-		"verified": "12"
+    "minimum": "13",
+		"verified": "13"
   },
   "esmodules": [
     "scripts/main.js"
@@ -29,8 +29,8 @@
     }
   ],
   "url": "https://github.com/TheComamba/AssetAuditor",
-  "manifest": "https://raw.githubusercontent.com/TheComamba/AssetAuditor/v1.1.0/src/module.json",
-  "download": "https://github.com/TheComamba/AssetAuditor/archive/refs/tags/v1.1.0.zip",
+  "manifest": "https://raw.githubusercontent.com/TheComamba/AssetAuditor/v2.0.0/src/module.json",
+  "download": "https://github.com/TheComamba/AssetAuditor/archive/refs/tags/v2.0.0.zip",
   "bugs": "https://github.com/TheComamba/AssetAuditor/issues",
-  "readme": "https://github.com/TheComamba/AssetAuditor/blob/v1.1.0/README.md"
+  "readme": "https://github.com/TheComamba/AssetAuditor/blob/v2.0.0/README.md"
 }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -32,23 +32,22 @@ Hooks.once('ready', async function () {
     }
 });
 
-Hooks.on("renderSidebarTab", async (app, html) => {
+Hooks.on("renderSidebar", async (app, html) => {
     if (!isUserPermitted()) {
         return;
     }
-    if (app instanceof Settings) {
-        let button_text = game.i18n.localize("asset-auditor.asset-filepaths");
-        let button = $(`<button class='asset-list'><i class='fas fa-file-edit'></i> ${button_text}</button>`)
+    
+    let button_text = game.i18n.localize("asset-auditor.asset-filepaths");
+    let $button = $(`<button class='asset-list'><i class='fas fa-file-edit'></i> ${button_text}</button>`)
 
-        button.click(function () {
-            new AssetFilepaths().render(true);
-        });
+    $button.click(function () {
+        new AssetFilepaths().render(true);
+    });
 
-        let settings_sidebar = html.find("div#settings-game");
-        if (settings_sidebar.length == 0) {
-            ui.notifications.error(game.i18n.localize("asset-auditor.sidebar-not-found"));
-            return;
-        }
-        settings_sidebar.append(button);
+    let settings_sidebar = document.querySelector('#settings .settings');
+    if (settings_sidebar.length == 0) {
+        ui.notifications.error(game.i18n.localize("asset-auditor.sidebar-not-found"));
+        return;
     }
-})
+    settings_sidebar.appendChild($button[0]);
+});


### PR DESCRIPTION
This drops support for Foundry 12 and below. Users of these version will have to keep using AssetAuditor 1.1.0.